### PR TITLE
Fixed paths and line endings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ services:
   - docker
 
 before_install:
-  - docker pull debian:stable-slim
+  - docker pull debian:stretch-slim
   - docker pull lacledeslan/steamcmd:linux
 
 script:
   - docker version
-  - docker build --no-cache --tag lltest/gamesvr-gesource --tag lacledeslan/gamesvr-gesource --build-arg BUILDNODE=TravisCI --build-arg SOURCE_COMMIT="$TRAVIS_COMMIT" ./linux
-  - docker run -it --rm lltest/gamesvr-gesource ./ll-tests/gamesvr-gesource.sh
+  - docker build --no-cache --tag lacledeslan/gamesvr-gesource:latest --tag lacledeslan/gamesvr-gesource:5.0.6 --build-arg BUILDNODE=TravisCI --build-arg SOURCE_COMMIT="$TRAVIS_COMMIT" ./linux
+  - docker run -it --rm lacledeslan/gamesvr-gesource:latest ./ll-tests/gamesvr-gesource.sh
 
 notifications:
   slack:
@@ -26,10 +26,14 @@ notifications:
 before_deploy:
   - echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USER" --password-stdin;
 deploy:
-  provider: script
-  script: docker push lacledeslan/gamesvr-gesource
-  on:
-    branch: master
+  - provider: script
+    script: docker push lacledeslan/gamesvr-gesource:latest
+    on:
+      branch: master
+  - provider: script
+    script: docker push lacledeslan/gamesvr-gesource:5.0.6
+    on:
+      branch: master
 after_deploy:
  - curl -X POST https://hooks.microbadger.com/images/lacledeslan/gamesvr-gesource/$MICROBADGER_TOKEN
  - sh ./.travis/trigger-travis.sh LacledesLAN gamesvr-gesource-freeplay $TRAVIS_ACCESS_TOKEN

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "cSpell.words": [
+        "freeplay",
+        "gamesvr",
+        "gesource",
+        "lacledeslan",
+        "steamcmd"
+    ]
+}

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -4,6 +4,8 @@ FROM lacledeslan/steamcmd:linux as gesource-builder
 
 ARG ftpServer=content.lacledeslan.net
 
+RUN apt-get update && apt-get install -y dos2unix && apt-get clean
+
 # Copy cached build files (if any)
 COPY ./build-cache /output
 
@@ -20,13 +22,10 @@ RUN echo "Downloading GoldenEye Source from LL public ftp server" &&`
 # Download Source 2007 Dedicated Server
 RUN /app/steamcmd.sh +login anonymous +force_install_dir /output/srcds2007 +app_update 310 validate +quit;
 
-COPY ./rename.sh /rename.sh
+COPY ./linuxify.sh /linuxify.sh
 
-RUN chmod +x /rename.sh && /rename.sh
-
-WORKDIR /output/gesource
-
-RUN apt-get update && apt-get install -y dos2unix && dos2unix *.txt && apt-get remove -y dos2unix && apt-get clean
+RUN chmod +x /linuxify.sh && /linuxify.sh &&`
+    /linuxify.sh;
 
 #=======================================================================
 FROM debian:stretch-slim

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -20,6 +20,14 @@ RUN echo "Downloading GoldenEye Source from LL public ftp server" &&`
 # Download Source 2007 Dedicated Server
 RUN /app/steamcmd.sh +login anonymous +force_install_dir /output/srcds2007 +app_update 310 validate +quit;
 
+COPY ./rename.sh /rename.sh
+
+RUN chmod +x /rename.sh && /rename.sh
+
+WORKDIR /output/gesource
+
+RUN apt-get update && apt-get install -y dos2unix && dos2unix *.txt && apt-get remove -y dos2unix && apt-get clean
+
 #=======================================================================
 FROM debian:stretch-slim
 

--- a/linux/linuxify.sh
+++ b/linux/linuxify.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
-IFS='
-'
+# This shell script ensures assets have been sanitized the Linux environment.
+# For details see PR #3 (https://github.com/LacledesLAN/gamesvr-gesource/pull/3).
+
+dos2unix /output/gesource/*.txt
+
+######
+
+IFS=$'\n'
+
 set -f
 
-rename_directory () {
+uppercase_directories () {
   for d in $(find "$1" -maxdepth 1 -type d -not -path "$1");
   do
     local upper=`echo "$d" | tr "[:lower:]" "[:upper:]"`
@@ -12,11 +19,11 @@ rename_directory () {
     then
       mv "$d" "$upper"
     fi
-    rename_directory "$upper"
+    uppercase_directories "$upper"
   done
 }
 
-rename_files () {
+uppercase_files () {
   for f in $(find . -type f);
   do
     local path=`echo "${f%.*}" | tr "[:lower:]" "[:upper:]"`
@@ -29,9 +36,9 @@ rename_files () {
 }
 
 cd /output/gesource/materials
-rename_directory "./"
-rename_files
+uppercase_directories "./"
+uppercase_files
 
 cd /output/srcds2007/hl2/materials
-rename_directory "./"
-rename_files
+uppercase_directories "./"
+uppercase_files

--- a/linux/rename.sh
+++ b/linux/rename.sh
@@ -5,7 +5,6 @@ IFS='
 set -f
 
 rename_directory () {
-  echo "$1"
   for d in $(find "$1" -maxdepth 1 -type d -not -path "$1");
   do
     local upper=`echo "$d" | tr "[:lower:]" "[:upper:]"`

--- a/linux/rename.sh
+++ b/linux/rename.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+IFS='
+'
+set -f
+
+rename_directory () {
+  echo "$1"
+  for d in $(find "$1" -maxdepth 1 -type d -not -path "$1");
+  do
+    local upper=`echo "$d" | tr "[:lower:]" "[:upper:]"`
+    if [ ! "$d" == "$upper" ]
+    then
+      mv "$d" "$upper"
+    fi
+    rename_directory "$upper"
+  done
+}
+
+rename_files () {
+  for f in $(find . -type f);
+  do
+    local path=`echo "${f%.*}" | tr "[:lower:]" "[:upper:]"`
+    local extension="${f##*.}"
+    if [ ! "$f" == "$path.$extension" ]
+    then
+      mv "$f" "$path.$extension"
+    fi
+  done
+}
+
+cd /output/gesource/materials
+rename_directory "./"
+rename_files
+
+cd /output/srcds2007/hl2/materials
+rename_directory "./"
+rename_files


### PR DESCRIPTION
Running the image on Centos 8, maps were failing to complete because the paths for their various assets (such as the vmt files) were uppercase and did not match the filesystem.

Long term I'd like to see if I can get the maps/models/textures/etc. updated upstream to use the proper pathing. Not sure how long that will take, or if it's possible, but for now this fix updates the filesystem to match the assets.

Additionally, some of the .txt configuration files were using windows line-endings, not unix style. this was causing issues trying to load them, so I ran dos2unix to fix that.